### PR TITLE
1.21 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.5-SNAPSHOT'
+	id 'fabric-loom' version '1.6-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -42,7 +42,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
@@ -51,8 +51,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
-loader_version=0.15.6
+minecraft_version=1.21
+yarn_mappings=1.21+build.9
+loader_version=0.16.5
 
 # Mod Properties
 mod_version=0.12
@@ -14,4 +14,4 @@ maven_group=net.justacoder.cursedworlds
 archives_base_name=cursedworlds
 
 # Dependencies
-fabric_version=0.95.4+1.20.4
+fabric_version=0.102.0+1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,9 +20,9 @@
 		"cursedworlds.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.15.6",
-		"minecraft": "~1.20.4",
-		"java": ">=17"
+		"fabricloader": ">=0.16.5",
+		"minecraft": ">=1.21",
+		"java": ">=21"
 	},
 	"accessWidener": "cursedworlds.accesswidener"
 }


### PR DESCRIPTION
**Consider adding a new branch for this**

*Adding a new branch would make maintenance for 1.20.4 versions possible in the future.*


This PR implements 1.21 support for the mod. I have tested it in 1.21 and 1.21.1.
Note that I haven't tested the generation for all world types, but it still works the same as in 1.20.4.

The only changes are by updating versions.
Please let me know if there needs to be any changes.